### PR TITLE
Update dnx-webui.service

### DIFF
--- a/dnx_system/utils/services/dnx-webui.service
+++ b/dnx_system/utils/services/dnx-webui.service
@@ -11,7 +11,7 @@ RestartSec=3
 User=dnx
 Group=dnx
 WorkingDirectory=/home/dnx/dnxfirewall
-ExecStart=uwsgi --socket dnx_webui/webui.sock --chmod-socket=660 --mount /=dnx_webui:app --master --processes 2 --enable-threads
+ExecStart=uwsgi --socket dnx_webui/webui.sock --safe-pidfile dnx_webui/webui.pid --chmod-socket=660 --mount /=dnx_webui:app --master --processes 2 --enable-threads --die-on-term
 
 Environment=INIT=True
 Environment=HOME_DIR=/home/dnx/dnxfirewall


### PR DESCRIPTION
This allows telling uWSGI that it should kill itself on SIGTERM instead of restarting.